### PR TITLE
change docker-compose to docker compose

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,23 +3,23 @@ SCRIPTS_PATH := ./srcs/scripts
 
 .PHONY: all
 all:
-	docker-compose -f $(YML_PATH) up --build -d
+	docker compose -f $(YML_PATH) up --build -d
 
 .PHONY: up
 up:
-	docker-compose -f $(YML_PATH) up -d
+	docker compose -f $(YML_PATH) up -d
 
 .PHONY: build
 build:
-	docker-compose -f $(YML_PATH) build
+	docker compose -f $(YML_PATH) build
 
 .PHONY: down clean
 clean down:
-	docker-compose -f $(YML_PATH) down
+	docker compose -f $(YML_PATH) down
 
 .PHONY: fclean
 fclean:
-	docker-compose -f $(YML_PATH) down --volumes
+	docker compose -f $(YML_PATH) down --volumes
 
 .PHONY: re
 re: fclean


### PR DESCRIPTION
평소 쓰던 mac이랑 다른 자리에서 make를 했는데 docker-compose 버전때문에 안되는 문제가 또 생겨서 좀 확인해보니 도커 컴포즈를 쓸 때 명령어를 docker-compose 로 하는게 아니라 docker compose 로 해야한다고 하네요.

docker-compose 는 v1 버전이고 docker compose 는 v2버전으로 v1은 23년 6월 이후로 지원이 만료됐고, v2는 docker에 통합되어서 플러그인으로 사용하는 것 같습니다.

저희 docker-compose.yml 파일에서는 v2의 기능을 사용하기 때문에 (include)

- **Makefile에서 docker-compose로 실행했던것을 docker compose 로 변경하였습니다.**

이전에 왜 잘 됐는지는 잘 모르겠네요...?