### PR TITLE
MyReact 버그 수정

### DIFF
--- a/srcs/requirements/node/conf/src/MyReact/MyReact.js
+++ b/srcs/requirements/node/conf/src/MyReact/MyReact.js
@@ -22,7 +22,7 @@ export function createTextElement(text) {
   };
 }
 
-function craeteDom(fiber) {
+function createDom(fiber) {
   const dom =
   fiber.type == "TEXT_ELEMENT"
     ? document.createTextNode("")
@@ -277,9 +277,9 @@ export function useEffect(callback, deps) {
 
 function updateHostComponent(fiber) {
   if (!fiber.dom) {
-    fiber.dom = craeteDom(fiber);
+    fiber.dom = createDom(fiber);
   }
-  const elements = [fiber.props.children];
+  const elements = fiber.props.children;
   reconcileChildren(fiber, elements);
 }
 


### PR DESCRIPTION
# 수정된 버그
1. setState 타이밍: 모든 컴포넌트의 업데이트가 끝난 이후에만 setSate를 적용하도록 변경
2. commitDeletion에서의 중복 삭제:  Deletion작업을 1번만 진행하게 변경
3. setState의 오타: tmpRoot.props의 오타 수정
4. 함수 오타: craeteDom -> createDom
5. 중복 배열: [fiber.props.children] -> fiber.props.children