### PR TITLE
fixed nginx CORS bug

### DIFF
--- a/srcs/compose_files/web.yml
+++ b/srcs/compose_files/web.yml
@@ -156,6 +156,8 @@ services:
     user: "0"
     image: owasp/modsecurity-crs:4.2.0-nginx-alpine-202405101205
     container_name: nginx
+    environment:
+      ALLOWED_METHODS: "GET POST PUT PATCH DELETE HEAD OPTIONS"
     volumes:
       - ${PROJECT_DIR}/requirements/nginx/conf/:/etc/nginx/templates/conf.d/:ro
       - certs_volume:/certs:ro


### PR DESCRIPTION
# 변경 사항
nginx 사용 시 PATCH method에 대한 CORS 문제 해결

# 원인
nginx의 보안 모듈인 modsecurity가 PATCH를 기본적으로 허용하지 않고 있었음.

# 해결
docker-compose.yml에서 환경변수 설정을 통한 PATCH허용