### PR TITLE
Fix: 닉네임 중복 관련 에러 처리

### DIFF
--- a/srcs/requirements/user_server/django/oauth/models.py
+++ b/srcs/requirements/user_server/django/oauth/models.py
@@ -1,5 +1,6 @@
 from django.db import models
 from user.models import User
+import string
 import random
 
 class OTPModel(models.Model):
@@ -13,8 +14,8 @@ class OTPModel(models.Model):
 		]
 
 	def save(self, *args, **kwargs):
-		key_set = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
-		self.code = ''.join(random.choice(key_set) for _ in range(6))
+		key_set = string.ascii_lowercase + string.ascii_uppercase + string.digits
+		self.code = ''.join(random.sample(key_set, 6))
 		super().save()
 
 


### PR DESCRIPTION
- 가입시 닉네임을 username과 동일하게 설정하는데, 해당 닉네임이 있는 경우 에러발생 -> 임의의 값 2개 추가하여 철
- random.choice 대신 random.sample 사용