### PR TITLE
added nginx img dir

### DIFF
--- a/srcs/compose_files/web.yml
+++ b/srcs/compose_files/web.yml
@@ -180,6 +180,7 @@ services:
       - logs_volume:/logs
       - avatars_volume:/django/avatars/:ro
       - node_volume:/node/:ro
+      - ${PROJECT_DIR}/requirements/node/conf/src/css/images:/images:ro
     ports:
       - 8000:8000
       - 8001:8001

--- a/srcs/requirements/nginx/conf/front.conf.template
+++ b/srcs/requirements/nginx/conf/front.conf.template
@@ -19,4 +19,9 @@ server {
         alias /django/avatars/;
         autoindex on;
     }
+
+    location /images {
+        alias /images/;
+        autoindex on;
+    }
 }


### PR DESCRIPTION
# 변경 사항
- nginx에 정적 이미지를 제공하는 기능 추가.

# 사용 방법
1. 원하는 이미지 파일을 "/srcs/requirments/node/conf/src/css/images" 경로에 넣는다.
2. nginx 컨테이너를 실행한다.
3. "https://localhost:4242/images/{path}" 를 통해 nginx로 부터 이미지를 받을 수 있다.
예시: /srcs/requirments/node/conf/src/css/images/ball/42-1.png 파일을 받으려면 "https://localhost:4242/images/ball/42-1.png" url 사용.